### PR TITLE
Updated README and added a first-draft Swagger spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # api-manager
-A set of configuration files, documentation, and sample code for the edX API Manager.
+A set of configuration files, documentation, and sample code for the Open edX API Manager
+
+## About
+The API Manager is a *work in progress* and is meant to define an independently deployable application that acts as an interface to developers building on top of Open edX REST APIs. The APIs listed in this repository are probably not a comprehensive list of the Open edX REST API set, but over time expect this list to grow.
+
+At the moment, this repository is a working prototype and is not officially supported or part of an Open edX release. As with other Open edX codebases, please take a look at [our Contributing docs](https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst) if you'd like to help build out this capability.
+
+## Specification
+The API Manager is defined by an [Open API / Swagger](https://github.com/OAI/OpenAPI-Specification) specification document at [swagger/api.yaml](swagger/api.yaml). You can point [swagger-codegen](https://github.com/swagger-api/swagger-codegen) at this document to generate a lightweight SDK in many languages, or just flatten the nested references into a single Swagger document using the `swagger` (JSON) or `swagger-yaml` (YAML) language options.
+
+## Vendor extensions
+Initially, we will provide vendor extensions for Amazon Web Services' [API Gateway](https://aws.amazon.com/api-gateway). The flattened Swagger document (see note above) should "just work" when using Amazon's `ImportRestApi` feature. Note that stage variables still need to be defined that are specific to your Open edX installation.
+
+In addition, the `api.yaml` file should also "just work" when loaded into Swagger UI (see http://petstore.swagger.io as an example)). Note that you will need to modify the base path and potentially instrument CORS headers if you want to use Swagger UI for truly interactive documentation. 

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -1,0 +1,43 @@
+# Swagger specification for the Open edX API
+# Note: not all API endpoints need to be listed here, just those that
+#  are part of your Open edX installation's "public API".
+
+---
+swagger: "2.0"
+info:
+  version: "1.0"
+  title: "Open edX"
+host: "api.your-open-edx-here.org"
+basePath: "/"
+schemes:
+- "https"
+
+# Complete set of whitelisted routes.
+# Upstream API owners: provide an fixed URI ref for each route.
+paths:
+
+  # OAuth2
+  "/oauth2/v1/access_token":
+    $ref: "./oauth.yaml#/endpoints/request_access_token"
+
+  # Discovery IDA
+  "/discovery/v1/catalogs":
+    $ref: "https://raw.githubusercontent.com/edx/course-discovery/a504273/api.yaml#/endpoints/v1/catalogs"
+  "/discovery/v1/catalogs/{id}":
+    $ref: "https://raw.githubusercontent.com/edx/course-discovery/a504273/api.yaml#/endpoints/v1/catalogsById"
+
+# Shared definitions, referenced by various API fragments
+# Note: AWS API Gateway requires that definitions are exclusively alphanumeric for now.
+definitions:
+  Bearer:
+    $ref: "./oauth.yaml#/definitions/Bearer"
+
+# edX extension point. Lists the vendors in use and their specific 
+#  parameters that are expected by upstream refs. 
+# Upstream API owners: document your dependencies in this index file to
+#  avoid conflicts with other upstreams.
+x-edx-api-vendors:
+  aws_apigateway:
+    stage_variables:
+    - "edxapp_host"
+    - "discovery_host"

--- a/swagger/oauth.yaml
+++ b/swagger/oauth.yaml
@@ -1,0 +1,89 @@
+---
+# This is a Swagger (swagger.org) specification fragment. It is
+# designed to be included into a top-level Swagger 'index', not
+# as a standalone document.
+
+endpoints:
+  request_access_token:
+    post:
+      operationId: request_access_token
+      tags:
+        - oauth2
+      parameters:
+        - in: formData
+          name: grant_type
+          required: true
+          type: string
+        - in: formData
+          name: client_id
+          required: true
+          type: string
+        - in: formData
+          name: client_secret
+          required: false
+          type: string
+          format: password
+        - in: formData
+          name: username
+          required: false
+          type: string
+        - in: formData
+          name: password
+          required: false
+          type: string
+          format: password
+      consumes:
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Bearer"
+        400:
+          description: "Bad Request"
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        404:
+          description: "Not Found"
+        429:
+          description: "Too Many Requests"
+        500:
+          description: "Internal Server Error"
+      x-amazon-apigateway-auth:
+        type: none
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        responses:
+          200:
+            statusCode: "200"
+          401:
+            statusCode: "401"
+          403:
+            statusCode: "403"
+          404:
+            statusCode: "404"
+          429:
+            statusCode: "429"
+          500:
+            statusCode: "500"
+          default:
+            statusCode: "400"
+        type: http
+        uri: "https://${stageVariables.edxapp_host}/oauth2/access_token"
+
+definitions:
+  Bearer:
+    properties:
+      access_token:
+        type: "string"
+      scope:
+        type: "string"
+      token_type:
+        type: "string"
+      expires_in:
+        type: "integer"
+        format: "int64"


### PR DESCRIPTION
Note that you can "validate" the Swagger spec by trying to generate an SDK with:
> `swagger-codegen generate -l swagger -i <https://raw version of api.yaml>`

That command requires the `swagger-codegen` tool (https://github.com/swagger-api/swagger-codegen).

@clintonb could you give this a once-over before I merge to master?