### PR TITLE
add more detail to local swagger documentation

### DIFF
--- a/swagger/heartbeat.yaml
+++ b/swagger/heartbeat.yaml
@@ -9,6 +9,10 @@ endpoints:
       operationId: "get_heartbeat"
       tags:
         - heartbeat
+      description: |
+        This endpoint returns basic "vital signs" for the Open edX API manager
+        in question. It can be used as a simple up/down liveness test or for a
+        more detailed (but still lightweight) analysis of the system.
       consumes:
         - "application/json"
       produces:
@@ -35,10 +39,19 @@ endpoints:
 
 definitions:
   heartbeat:
-    required:
-      - version
     properties:
       version:
         type: "string" 
+        description: |
+          Open edX API version, typically represented as "major.minor.micro".
+          The versioning lifecycle rules will be specific to your Open edX installation.
+        example: "1.0.0"
       id:
         type: "string"
+        description: |
+          Unique configuration deployment identification code, optional and specific to
+          your Open edX installation. For example, this value could be the git hash of
+          the configuration used to spin up the API manager.
+        example: "7effb8a"
+    required:
+      - version

--- a/swagger/oauth.yaml
+++ b/swagger/oauth.yaml
@@ -9,6 +9,11 @@ endpoints:
       operationId: request_access_token
       tags:
         - oauth2
+      description: |
+        To request an access token, the client obtains authorization from the
+        resource owner.  The authorization is expressed in the form of an
+        authorization grant, which the client uses to request the access
+        token. See https://tools.ietf.org/html/rfc6749#section-4 for more detail.
       parameters:
         - in: formData
           name: grant_type
@@ -82,20 +87,34 @@ endpoints:
 
 definitions:
   bearer:
+    properties:
+      access_token:
+        type: "string"
+        description: "The access token issued by the authorization server."
+        example: "2YotnFZFEjr1zCsicMWpAA"
+      refresh_token:
+        type: "string"
+        description: |
+          Refresh tokens are credentials used to obtain new access tokens once
+          authorization has already been granted.
+        example: "tGzv3JOkF0XG5Qx2TlKWIA"
+      scope:
+        type: "string"
+        description: |
+          Whitespace-delimited list of associated scopes. Can be an empty string.
+          See https://tools.ietf.org/html/rfc6749#section-3.3 for more detail.
+        example: "read write"
+      token_type:
+        type: "string"
+        description: "The type of the token issued. Value is case insensitive."
+        example: "Bearer"
+      expires_in:
+        type: "integer"
+        format: "int64"
+        description: "The lifetime in seconds of the access token."
+        example: 60
     required:
       - access_token
       - scope
       - token_type
       - expires_in
-    properties:
-      access_token:
-        type: "string"
-      refresh_token:
-        type: "string"
-      scope:
-        type: "string"
-      token_type:
-        type: "string"
-      expires_in:
-        type: "integer"
-        format: "int64"


### PR DESCRIPTION
@jcdyer I added some detail to the oauth swagger doc to better describe what each field means and added some examples. I ripped a lot of it off RFC6749 directly - can you quickly scan this for accuracy before I merge? Not urgent! I also added some detail around my custom heartbeat endpoint while I was in the codebase.