### PR TITLE
commenting out examples

### DIFF
--- a/swagger/heartbeat.yaml
+++ b/swagger/heartbeat.yaml
@@ -45,13 +45,13 @@ definitions:
         description: |
           Open edX API version, typically represented as "major.minor.micro".
           The versioning lifecycle rules will be specific to your Open edX installation.
-        example: "1.0.0"
+        # example: "1.0.0"
       id:
         type: "string"
         description: |
           Unique configuration deployment identification code, optional and specific to
           your Open edX installation. For example, this value could be the git hash of
           the configuration used to spin up the API manager.
-        example: "7effb8a"
+        # example: "7effb8a"
     required:
       - version

--- a/swagger/oauth.yaml
+++ b/swagger/oauth.yaml
@@ -91,28 +91,28 @@ definitions:
       access_token:
         type: "string"
         description: "The access token issued by the authorization server."
-        example: "2YotnFZFEjr1zCsicMWpAA"
+        # example: "2YotnFZFEjr1zCsicMWpAA"
       refresh_token:
         type: "string"
         description: |
           Refresh tokens are credentials used to obtain new access tokens once
           authorization has already been granted.
-        example: "tGzv3JOkF0XG5Qx2TlKWIA"
+        # example: "tGzv3JOkF0XG5Qx2TlKWIA"
       scope:
         type: "string"
         description: |
           Whitespace-delimited list of associated scopes. Can be an empty string.
           See https://tools.ietf.org/html/rfc6749#section-3.3 for more detail.
-        example: "read write"
+        # example: "read write"
       token_type:
         type: "string"
         description: "The type of the token issued. Value is case insensitive."
-        example: "Bearer"
+        # example: "Bearer"
       expires_in:
         type: "integer"
         format: "int64"
         description: "The lifetime in seconds of the access token."
-        example: 60
+        # example: 60
     required:
       - access_token
       - scope


### PR DESCRIPTION
because - while it's valid Swagger 2.0 and just a comment field - AWS can't handle its presence. ladies and gentlemen, I present 'the cloud'