### PR TITLE
add test stubs for flip.py and bootstrap.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Travis CI configuration file for running tests
+sudo: false
+language: python
+branches:
+    only:
+      - master
+python:
+  - "2.7"
+install:
+  - make requirements
+script:
+  - make validate

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ clean:
 	find . -name '*.pyc' -delete
 
 test_scripts:
-	cd scripts/aws && python -m pytest -v tests/test_deploy.py
+	pip install -qr requirements/test.txt --exists-action w
+	cd scripts/aws && python -m pytest
 
 validate_python: clean
 	make quality

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,16 @@ help:
 	@echo '                                                                                     		'
 
 requirements:
-	pip install -qr requirements/local.txt --exists-action w
+	pip install -qr requirements/test.txt --exists-action w
 
 clean:
 	find . -name '*.pyc' -delete
 
 test_scripts:
-	pip install -qr requirements/test.txt --exists-action w
 	cd scripts/aws && python -m pytest
 
-validate_python: clean
+validate_python:
+	make clean
 	make quality
 	make test_scripts
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# api-manager
+# api-manager [![Build Status](https://travis-ci.org/edx/api-manager.svg?branch=master)](https://travis-ci.org/edx/api-manager)
 Specifications and optional lightweight service for routing clients of the Open edX REST API to various endpoints within the platform.
 
 ## About

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 # Packages required for testing
 -r base.txt
 
-pep8==1.7.0
-pytest==2.9.1
 moto==0.4.24
+pep8==1.7.0
+pylint==1.5.5
+pytest==2.9.1

--- a/scripts/aws/tests/fixtures/swagger.json
+++ b/scripts/aws/tests/fixtures/swagger.json
@@ -1,0 +1,43 @@
+{
+      "swagger": "2.0",
+      "info": {
+        "version": "0.0.0",
+        "title": "test"
+      },
+      "host": "api.example.org",
+      "basePath": "/",
+      "schemes": [
+        "https"
+      ],
+      "paths": {
+        "/": {
+          "get": {
+            "consumes": [
+              "application/json"
+            ],
+            "produces": [
+              "application/json"
+            ],
+            "responses": {
+              "200": {
+                "description": "OK"
+              }
+            },
+            "x-amazon-apigateway-integration": {
+              "responses": {
+                "default": {
+                  "statusCode": "200",
+                  "responseTemplates": {
+                    "application/json": "{\"hello\": \"world\"}"
+                  }
+                }
+              },
+              "requestTemplates": {
+                "application/json": "{\"statusCode\": 200}"
+              },
+              "type": "mock"
+            }
+          }
+        }
+      }
+    }

--- a/scripts/aws/tests/test_bootstrap.py
+++ b/scripts/aws/tests/test_bootstrap.py
@@ -1,0 +1,36 @@
+"""
+Tests for scripts/aws/bootstrap.py
+"""
+import boto3
+import pytest
+from moto import mock_apigateway, mock_route53
+from unittest import TestCase
+from bootstrap import get_domain, get_base_path, create_apigw_custom_domain_name,\
+    create_route53_rs, bootstrap_api, create_base_path_mapping, file_arg_to_string
+
+
+class BootstrapTest(TestCase):
+    """
+    TestCase class for testing bootstrap.py
+    """
+
+    def setUp(self):
+        self.api_base_domain = 'api.fake-host.com'
+        self.cloudfront_zone = 'fake-zone'
+        self.distribution_name = 'fake-distro'
+
+    @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:GetDomainName")
+    def test_get_domain(self):
+        pass
+
+    @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:GetBasePathMapping")
+    def test_get_base_path(self):
+        pass
+
+    @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:CreateDomainName")
+    def test_create_apigw_custom_domain_name(self):
+        pass
+
+    @pytest.mark.skip(reason="moto does not yet support AWS:Route53:ChangeResourceRecordSets")
+    def test_create_route53_rs(self):
+        pass

--- a/scripts/aws/tests/test_deploy.py
+++ b/scripts/aws/tests/test_deploy.py
@@ -15,13 +15,13 @@ class DeployTest(TestCase):
 
     @mock_apigateway
     def setUp(self):
-        self.access_key = 'fake-access-key'
-        self.secret_key = 'fake-secret-key'
         self.rotation = ['red', 'black', 'turquoise']
-        self.client = boto3.client('apigateway', 'us-east-1')
-        self.rest_api = self.client.create_rest_api(name='test', description='desc')
+        self.current_stage = 'black'
+        self.api_base_domain = 'api.fake-host.com'
+        self.swagger_filename = 'fixtures/swagger.json'
 
     @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:GetBasePathMapping")
+    @mock_apigateway
     def test_get_api_id(self):
         pass
 
@@ -39,21 +39,12 @@ class DeployTest(TestCase):
             actual_next_stage = get_next_stage(self.rotation, expected_rotation['current'])
             self.assertEqual(expected_rotation['next'], actual_next_stage)
 
-    @pytest.mark.xfail(raises=TypeError, reason="moto does not yet support AWS:ApiGateway:PutRestApi")
+    @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:PutRestApi")
     @mock_apigateway
     def test_deploy_api(self):
-        deploy_api(self.client, self.rest_api['id'], 'bootstrap.json', 'stage', {
-            'key1': 'value1',
-            'key2': 'value2'
-        })
+        pass
 
     @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:UpdateStage")
     @mock_apigateway
     def test_update_stage(self):
-        update_stage(self.client, self.rest_api['id'], 'stage', {
-            'log_level': 'INFO',
-            'metrics': 'true',
-            'caching': 'false',
-            'rate_limit': '9',
-            'burst_limit': '9000'
-        })
+        pass

--- a/scripts/aws/tests/test_flip.py
+++ b/scripts/aws/tests/test_flip.py
@@ -1,0 +1,28 @@
+"""
+Tests for scripts/aws/flip.py
+"""
+import boto3
+import pytest
+from moto import mock_apigateway
+from unittest import TestCase
+from flip import get_live_stage, update_base_path_mapping
+
+
+class FlipTest(TestCase):
+    """
+    TestCase class for testing flip.py
+    """
+
+    def setUp(self):
+        self.api_base_domain = 'api.fake-host.com'
+        self.rotation = ['red', 'black', 'turquoise']
+        self.current_stage = 'black'
+        self.next_stage = 'turquoise'
+
+    @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:GetBasePathMapping")
+    def test_get_live_stage(self):
+        pass
+
+    @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:UpdateBasePathMapping")
+    def test_update_base_path_mapping(self):
+        pass


### PR DESCRIPTION
@jzoldak updated pull request for your review. Files of interest: everything in `scripts/aws/tests` and the top-level `Makefile`. The only active test is in `test_deploy.py` because `moto` turns out to have virtually none of the high-level / newer boto calls I need, so I'm not entirely sure how much testing we can/want to do there right now.