### PR TITLE
add a few negative tests to stage rotation logic

### DIFF
--- a/scripts/aws/tests/test_deploy.py
+++ b/scripts/aws/tests/test_deploy.py
@@ -32,12 +32,17 @@ class DeployTest(TestCase):
         expected_rotations = [
             {'current': 'red', 'next': 'black'},
             {'current': 'black', 'next': 'turquoise'},
-            {'current': 'turquoise', 'next': 'red'}
+            {'current': 'turquoise', 'next': 'red'},
+            {'current': 'not-in-rotation', 'next': 'red'}
         ]
 
         for expected_rotation in expected_rotations:
             actual_next_stage = get_next_stage(self.rotation, expected_rotation['current'])
             self.assertEqual(expected_rotation['next'], actual_next_stage)
+
+        # test behavior with a bad rotation
+        with self.assertRaises(ValueError):
+            get_next_stage([], 'red')
 
     @pytest.mark.skip(reason="moto does not yet support AWS:ApiGateway:PutRestApi")
     @mock_apigateway


### PR DESCRIPTION
@jzoldak one more for you to review, please - filled out the stage-rotation logic tests to include two more assertions focused on negative cases:
- what happens when "rotating" from a stage that isn't in the rotation? (should: start from the beginning of the rotation order)
- what happens when there is no rotation? (should: throw an error)