### PR TITLE
latest swagger-codegen supports naming inline models...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ python-libs/
 ### Test artifacts
 .cache
 swagger-codegen-cli.jar
+swagger.yaml
+.swagger-codegen-ignore
 edx-api-stub-server/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SWAGGER_CODEGEN_JAR := http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.1.6/swagger-codegen-cli-2.1.6.jar
+SWAGGER_CODEGEN_JAR := http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.1/swagger-codegen-cli-2.2.1.jar
 BUILD_OUTPUT_DIR := swagger-build-artifacts
 STUB_SERVER_DIR := edx-api-stub-server
 

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -36,17 +36,6 @@ paths:
   "/catalog/v1/catalogs/{id}/courses":
       $ref: "https://raw.githubusercontent.com/edx/course-discovery/649a4cb/api.yaml#/endpoints/v1/catalogCourses"
 
-# swagger-codegen automatically generates "inline_response_*" models for inline schemas.
-#   Unfortunately, AWS API Gateway can only handle alphanumeric model names (facepalm).
-#   So, at least for now, you can't inline schemas until AWS fixes this, and you need to
-#   declare any referenced definitions here because Swagger doesn't let you actually import
-#   document fragments, you're really importing path and definition fragments separately. Yay!
-definitions:
-  heartbeat:
-    $ref: "./heartbeat.yaml#/definitions/heartbeat"
-  bearer:
-    $ref: "./oauth.yaml#/definitions/bearer"
-
 # edX extension point. Lists the vendors in use and their specific 
 #  parameters that are expected by upstream refs. 
 # Upstream API owners: document your dependencies in this index file to

--- a/swagger/heartbeat.yaml
+++ b/swagger/heartbeat.yaml
@@ -21,7 +21,23 @@ endpoints:
         200:
           description: "OK"
           schema:
-            $ref: "#/definitions/heartbeat"
+            title: "heartbeat"
+            properties:
+              version:
+                type: "string"
+                description: |
+                  Open edX API version, typically represented as "major.minor.micro".
+                  The versioning lifecycle rules will be specific to your Open edX installation.
+                # example: "1.0.0"
+              id:
+                type: "string"
+                description: |
+                  Unique configuration deployment identification code, optional and specific to
+                  your Open edX installation. For example, this value could be the git hash of
+                  the configuration used to spin up the API manager.
+                # example: "7effb8a"
+            required:
+              - version
       x-amazon-apigateway-integration:
         responses:
           default:
@@ -36,22 +52,3 @@ endpoints:
           application/json: |
                 {"statusCode": 200}
         type: "mock"
-
-definitions:
-  heartbeat:
-    properties:
-      version:
-        type: "string" 
-        description: |
-          Open edX API version, typically represented as "major.minor.micro".
-          The versioning lifecycle rules will be specific to your Open edX installation.
-        # example: "1.0.0"
-      id:
-        type: "string"
-        description: |
-          Unique configuration deployment identification code, optional and specific to
-          your Open edX installation. For example, this value could be the git hash of
-          the configuration used to spin up the API manager.
-        # example: "7effb8a"
-    required:
-      - version

--- a/swagger/oauth.yaml
+++ b/swagger/oauth.yaml
@@ -54,7 +54,38 @@ endpoints:
         200:
           description: OK
           schema:
-            $ref: "#/definitions/bearer"
+            title: "bearer"
+            properties:
+              access_token:
+                type: "string"
+                description: "The access token issued by the authorization server."
+                # example: "2YotnFZFEjr1zCsicMWpAA"
+              refresh_token:
+                type: "string"
+                description: |
+                  Refresh tokens are credentials used to obtain new access tokens once
+                  authorization has already been granted.
+                # example: "tGzv3JOkF0XG5Qx2TlKWIA"
+              scope:
+                type: "string"
+                description: |
+                  Whitespace-delimited list of associated scopes. Can be an empty string.
+                  See https://tools.ietf.org/html/rfc6749#section-3.3 for more detail.
+                # example: "read write"
+              token_type:
+                type: "string"
+                description: "The type of the token issued. Value is case insensitive."
+                # example: "Bearer"
+              expires_in:
+                type: "integer"
+                format: "int64"
+                description: "The lifetime in seconds of the access token."
+                # example: 60
+            required:
+              - access_token
+              - scope
+              - token_type
+              - expires_in
         400:
           description: "Bad Request"
         401:
@@ -88,37 +119,3 @@ endpoints:
             statusCode: "400"
         type: http
         uri: "https://${stageVariables.edxapp_host}/oauth2/access_token"
-
-definitions:
-  bearer:
-    properties:
-      access_token:
-        type: "string"
-        description: "The access token issued by the authorization server."
-        # example: "2YotnFZFEjr1zCsicMWpAA"
-      refresh_token:
-        type: "string"
-        description: |
-          Refresh tokens are credentials used to obtain new access tokens once
-          authorization has already been granted.
-        # example: "tGzv3JOkF0XG5Qx2TlKWIA"
-      scope:
-        type: "string"
-        description: |
-          Whitespace-delimited list of associated scopes. Can be an empty string.
-          See https://tools.ietf.org/html/rfc6749#section-3.3 for more detail.
-        # example: "read write"
-      token_type:
-        type: "string"
-        description: "The type of the token issued. Value is case insensitive."
-        # example: "Bearer"
-      expires_in:
-        type: "integer"
-        format: "int64"
-        description: "The lifetime in seconds of the access token."
-        # example: 60
-    required:
-      - access_token
-      - scope
-      - token_type
-      - expires_in

--- a/tests/test_heartbeat.yaml
+++ b/tests/test_heartbeat.yaml
@@ -8,5 +8,5 @@
     - method: 'GET'
     - expected_status: [200]
     - validators:
-        - compare: {jsonpath_mini: 'version', comparator: 'eq', expected: 'Sample text'}
-        - compare: {jsonpath_mini: 'id', comparator: 'eq', expected: 'Sample text'}
+        - compare: {jsonpath_mini: 'version', comparator: 'eq', expected: 'aeiou'}
+        - compare: {jsonpath_mini: 'id', comparator: 'eq', expected: 'aeiou'}

--- a/tests/test_oauth.yaml
+++ b/tests/test_oauth.yaml
@@ -32,8 +32,8 @@
     - body: 'grant_type=foo&client_id=bar'
     - expected_status: [200]
     - validators:
-        - compare: {jsonpath_mini: 'access_token', comparator: 'eq', expected: 'Sample text'}
-        - compare: {jsonpath_mini: 'refresh_token', comparator: 'eq', expected: 'Sample text'}
-        - compare: {jsonpath_mini: 'scope', comparator: 'eq', expected: 'Sample text'}
-        - compare: {jsonpath_mini: 'token_type', comparator: 'eq', expected: 'Sample text'}
-        - compare: {jsonpath_mini: 'expires_in', comparator: 'eq', expected: 1}
+        - compare: {jsonpath_mini: 'access_token', comparator: 'eq', expected: 'aeiou'}
+        - compare: {jsonpath_mini: 'refresh_token', comparator: 'eq', expected: 'aeiou'}
+        - compare: {jsonpath_mini: 'scope', comparator: 'eq', expected: 'aeiou'}
+        - compare: {jsonpath_mini: 'token_type', comparator: 'eq', expected: 'aeiou'}
+        - compare: {jsonpath_mini: 'expires_in', comparator: 'eq', expected: 123456789}


### PR DESCRIPTION
... time to pay down some tech debt and start inlining some models!

Details:
- In the past, inline models were automatically named `inline_model_X`. AWS API Gateway doesn't allow for model names with underscores.
- The latest version of `swagger-codegen`, 2.2.1 (released last week), supports the `title` field for custom names of inline models.
- This PR inlines the two model definitions that exist today and removes them from the top-level `api.yaml` file, which is a nice bit of cleanup and allows for even more team autonomy in defining gateway endpoints.
- Another plus is that we're now able to bump the version of swagger codegen and take all the latest changes (2.2.1 doesn't work without the updated YAML)