### PR TITLE
Update swagger-codegen version used for testing to 2.2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SWAGGER_CODEGEN_JAR := http://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.1/swagger-codegen-cli-2.2.1.jar
+SWAGGER_CODEGEN_JAR := http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.2/swagger-codegen-cli-2.2.2.jar
 BUILD_OUTPUT_DIR := swagger-build-artifacts
 STUB_SERVER_DIR := edx-api-stub-server
 


### PR DESCRIPTION
@jzoldak: please review. swagger-codegen 2.2.2 came out last week, I wanted to bump the version that we use for testing accordingly (the 2.2.1 release was from Aug 2016).

@mattdrayer @saleem-latif: fyi. Shouldn't impact your work, but you may wish to rebase.