### PR TITLE
Update enterprise endpoint hash

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -38,14 +38,14 @@ paths:
 
   # Enterprise IDA
   "/enterprise/v1/catalogs":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/43ea09b/api.yaml#/endpoints/v1/enterpriseCatalogs"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/e40d625/api.yaml#/endpoints/v1/enterpriseCatalogs"
   "/enterprise/v1/catalogs/{id}":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/43ea09b/api.yaml#/endpoints/v1/enterpriseCatalogById"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/e40d625/api.yaml#/endpoints/v1/enterpriseCatalogById"
   "/enterprise/v1/catalogs/{id}/courses":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/43ea09b/api.yaml#/endpoints/v1/enterpriseCatalogCourses"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/e40d625/api.yaml#/endpoints/v1/enterpriseCatalogCourses"
 
 # edX extension point. Lists the vendors in use and their specific
-#  parameters that are expected by upstream refs. 
+#  parameters that are expected by upstream refs.
 # Upstream API owners: document your dependencies in this index file to
 #  avoid conflicts with other upstreams.
 x-edx-api-vendors:


### PR DESCRIPTION
@efagin @douglashall @saleem-latif -- had to fix the enterprise API endpoint mappings (see https://github.com/edx/edx-enterprise/pull/99).

This PR updates the hash used in the Github reference so it pulls in the updated mapping.