### PR TITLE
bump dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 	rm -rf $(STUB_SERVER_DIR)
 
 requirements:
-	pip install -qr requirements/test.txt --exists-action w
+	pip install -qr requirements/test-requirements.txt --exists-action w
 
 quality:
 	pep8 --config=.pep8 scripts/aws

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto3==1.4.4
-botocore==1.5.46
+botocore==1.5.55
 jmespath==0.9.2
 six==1.10.0
 Jinja2==2.9.6

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,8 +1,9 @@
 # Packages required for testing
 -r base.txt
 
-moto==0.4.31
+moto==1.0.0
+mock==2.0.0
 pep8==1.7.0
 pylint==1.7.1
 pyresttest==1.7.1
-pytest==3.0.7
+pytest==3.1.0


### PR DESCRIPTION
@jzoldak looks like moto just released 1.0.0, which has a bug (https://github.com/spulec/moto/issues/950) that can be worked around by also pulling in mock-2.0.0 directly, so I've done that here. Once moto bumps to 1.0.1+ we can probably safely remove mock from directly being required by this project.