### PR TITLE
ENT-472: Add gateway_host stage variable for api deployments

### DIFF
--- a/scripts/aws/README.md
+++ b/scripts/aws/README.md
@@ -29,6 +29,7 @@ First, make sure `AWS_REGION`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` a
 There are a few custom environment variables required for the `deploy` script to work. At some point, we'll probably move some of these to be command-line arguments.
 * `STAGE_ROTATION_ORDER`: comma-separated list of stages in your "ring". Be aware of your AWS account's limit on stages per gateway. Example: `red,black`
 * `STAGE_EDXAPP_HOST`: the API base of your edx-platform service deployment
+* `STAGE_GATEWAY_HOST`: the API manager's host
 * `STAGE_DISCOVERY_HOST`: the API base of your course-discovery service deployment (just set to an empty or dummy string if you aren't using this in your specific Open edX deployment)
 * `STAGE_ENTERPRISE_HOST`: the API base of your enterprise service deployment (just set to an empty or dummy string if you aren't using this in your specific Open edX deployment)
 

--- a/scripts/aws/deploy.py
+++ b/scripts/aws/deploy.py
@@ -130,6 +130,8 @@ if __name__ == '__main__':
                         help="Location of catalog IDA for request routing")
     parser.add_argument("--enterprise-host", required=False, default='',
                         help="Location of enterprise IDA for request routing")
+    parser.add_argument("--gateway-host", required=False, default='localhost',
+                        help="Host name of the api deployment.")
 
     args = parser.parse_args()
 
@@ -149,6 +151,7 @@ if __name__ == '__main__':
         'edxapp_host': args.edxapp_host,
         'discovery_host': args.catalog_host,
         'enterprise_host': args.enterprise_host or args.edxapp_host,
+        'gateway_host': args.gateway_host,
     })
 
     # Apply stage setting updates.

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -56,3 +56,4 @@ x-edx-api-vendors:
     - "edxapp_host"
     - "discovery_host"
     - "enterprise_host"
+    - "gateway_host"


### PR DESCRIPTION
Hi @efagin , @mattdrayer , @douglashall 

Please take a look at the PR, I have added a new stage variable named `gateway_host` that will contain the api manager's host.
