### PR TITLE
ENT-472: Update api.yaml refs for enterprise api.

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -38,11 +38,11 @@ paths:
 
   # Enterprise IDA
   "/enterprise/v1/catalogs":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/5843507/api.yaml#/endpoints/v1/enterpriseCatalogs"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/e1c3153/api.yaml#/endpoints/v1/enterpriseCatalogs"
   "/enterprise/v1/catalogs/{id}":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/5843507/api.yaml#/endpoints/v1/enterpriseCatalogById"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/e1c3153/api.yaml#/endpoints/v1/enterpriseCatalogById"
   "/enterprise/v1/catalogs/{id}/courses":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/5843507/api.yaml#/endpoints/v1/enterpriseCatalogCourses"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/e1c3153/api.yaml#/endpoints/v1/enterpriseCatalogCourses"
 
 # edX extension point. Lists the vendors in use and their specific
 #  parameters that are expected by upstream refs.


### PR DESCRIPTION
Hi @efagin , @douglashall ,

Please take a look at this, I have updated "ref" URLs for enterprise api config. Enterprise API config now points to [0.38.5](https://github.com/edx/edx-enterprise/releases/tag/0.38.5) that contains the changes merged in https://github.com/edx/edx-enterprise/pull/146

FYI, @zubair-arbi , @asadiqbal08 