### PR TITLE
Separate discovery/catalog endpoint structure

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -29,10 +29,12 @@ paths:
     $ref: "./oauth.yaml#/endpoints/request_access_token"
 
   # Discovery IDA
-  # Base Discovery Endpoints
-  "/v1/courses":
+  # Discovery and Catalog are both actually served from the course-discovery IDA
+  # but we separate them here to distinguish between the different use cases
+  "/discovery/v1/courses":
     $ref: "https://raw.githubusercontent.com/edx/course-discovery/e855990/api.yaml#/endpoints/v1/courses"
-  # Catalog Endpoints
+
+  # Catalog IDA
   "/catalog/v1/catalogs":
     $ref: "https://raw.githubusercontent.com/edx/course-discovery/e855990/api.yaml#/endpoints/v1/catalogs"
   "/catalog/v1/catalogs/{id}":

--- a/tests/test_all.yaml
+++ b/tests/test_all.yaml
@@ -2,5 +2,6 @@
 - import: 'tests/test_heartbeat.yaml'
 - import: 'tests/test_index.yaml'
 - import: 'tests/test_oauth.yaml'
+- import: 'tests/test_catalog.yaml'
 - import: 'tests/test_discovery.yaml'
 - import: 'tests/test_enterprise.yaml'

--- a/tests/test_catalog.yaml
+++ b/tests/test_catalog.yaml
@@ -1,0 +1,37 @@
+---
+- config:
+    - testset: 'Catalog API'
+
+- test:
+    - name: 'Catalogs endpoint returns HTTP 200'
+    - url: '/catalog/v1/catalogs'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [200]
+
+- test:
+    - name: 'Catalog by ID endpoint returns HTTP 200'
+    - url: '/catalog/v1/catalogs/1'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [200]
+
+- test:
+    - name: 'Catalog courses endpoint returns HTTP 200'
+    - url: '/catalog/v1/catalogs/1/courses'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [200]
+
+- test:
+    - name: 'POST is disabled for catalogs'
+    - url: '/catalog/v1/catalogs'
+    - method: 'POST'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [405]
+
+- test:
+    - name: 'GET rejected without authorization'
+    - url: '/catalog/v1/catalogs'
+    - method: 'GET'
+    - expected_status: [400]

--- a/tests/test_discovery.yaml
+++ b/tests/test_discovery.yaml
@@ -3,48 +3,14 @@
     - testset: 'Discovery API'
 
 - test:
-    - name: 'Base courses endpoint returns HTTP 200'
-    - url: '/v1/courses'
+    - name: 'Discovery courses endpoint returns HTTP 200'
+    - url: '/discovery/v1/courses'
     - method: 'GET'
     - headers: {'Authorization': 'aeiou'}
     - expected_status: [200]
 
 - test:
-    - name: 'Base courses endpoint rejects without authorization'
-    - url: '/v1/courses'
-    - method: 'GET'
-    - expected_status: [400]
-
-- test:
-    - name: 'Catalogs endpoint returns HTTP 200'
-    - url: '/catalog/v1/catalogs'
-    - method: 'GET'
-    - headers: {'Authorization': 'aeiou'}
-    - expected_status: [200]
-
-- test:
-    - name: 'Catalog by ID endpoint returns HTTP 200'
-    - url: '/catalog/v1/catalogs/1'
-    - method: 'GET'
-    - headers: {'Authorization': 'aeiou'}
-    - expected_status: [200]
-
-- test:
-    - name: 'Catalog courses endpoint returns HTTP 200'
-    - url: '/catalog/v1/catalogs/1/courses'
-    - method: 'GET'
-    - headers: {'Authorization': 'aeiou'}
-    - expected_status: [200]
-
-- test:
-    - name: 'POST is disabled for catalogs'
-    - url: '/catalog/v1/catalogs'
-    - method: 'POST'
-    - headers: {'Authorization': 'aeiou'}
-    - expected_status: [405]
-
-- test:
-    - name: 'GET rejected without authorization'
-    - url: '/catalog/v1/catalogs'
+    - name: 'Discovery courses endpoint rejects without authorization'
+    - url: '/discovery/v1/courses'
     - method: 'GET'
     - expected_status: [400]


### PR DESCRIPTION
Separate the `course-discovery` endpoints into a base `discovery` and `catalog` endpoint structure, since in an ideal world `catalog` would likely be its own separate IDA