### PR TITLE
Add registrar v2 API proxy

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -130,6 +130,19 @@ paths:
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
 
+  "/registrar/v2/{proxy+}":
+    x-amazon-apigateway-any-method:
+      parameters:
+      - name: "proxy"
+        in: "path"
+      x-amazon-apigateway-integration:
+        type: "http_proxy"
+        uri: "https://${stageVariables.registrar_host}/api/v2/{proxy}/"
+        httpMethod: "ANY"
+        requestParameters:
+          integration.request.path.proxy: "method.request.path.proxy"
+
+
 # edX extension point. Lists the vendors in use and their specific
 #  parameters that are expected by upstream refs.
 # Upstream API owners: document your dependencies in this index file to


### PR DESCRIPTION
Follow up to the registrar API v2 release - need to add a proxy section for it in the API manager.