### PR TITLE
Remove Registrar V1 Mock API from Amazon API proxy

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -106,18 +106,6 @@ paths:
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
 
-  "/registrar/v1-mock/{proxy+}":
-    x-amazon-apigateway-any-method:
-      parameters:
-      - name: "proxy"
-        in: "path"
-      x-amazon-apigateway-integration:
-        type: "http_proxy"
-        uri: "https://${stageVariables.registrar_host}/api/v1-mock/{proxy}/"
-        httpMethod: "ANY"
-        requestParameters:
-          integration.request.path.proxy: "method.request.path.proxy"
-
   "/registrar/v2/{proxy+}":
     x-amazon-apigateway-any-method:
       parameters:


### PR DESCRIPTION
@edx/masters-devs 

Follow up on https://github.com/edx/registrar/pull/189, need to remove registrar v1 mock api from our Amazon proxy.

ticket number: EDUCATOR-4676