### PR TITLE
Add all missing enterprise v1 endpoints to v2

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -57,6 +57,17 @@ paths:
     $ref: "https://raw.githubusercontent.com/edx/enterprise-catalog/2877ad7/api.yaml#/endpoints/v2/enterpriseCatalogs"
   "/enterprise/v2/enterprise-catalogs/{uuid}":
     $ref: "https://raw.githubusercontent.com/edx/enterprise-catalog/2877ad7/api.yaml#/endpoints/v2/enterpriseCatalogByUuid"
+  # Add the following v1 endpoints to v2 with the same implementation for ease of use by the ECS team
+  "/enterprise/v2/enterprise-catalogs/{uuid}/course-runs/{course_run_id}":
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCatalogCourseRunByUuid"
+  "/enterprise/v2/enterprise-catalogs/{uuid}/courses/{course_key}":
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCatalogCourseByKey"
+  "/enterprise/v2/enterprise-catalogs/{uuid}/programs/{program_uuid}":
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCatalogProgramByUuid"
+  "/enterprise/v2/enterprise-customer/{uuid}/course-enrollments":
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCourseEnrollments"
+  "/enterprise/v2/enterprise-customer/{uuid}/learner-summary":
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/8fc95e4/api.yaml#/endpoints/v1/enterpriseCustomerLearnerSummary"
 
   # Registrar API Proxy
   # Note: There's an unresolved issue involving trailing slashes with proxy integrations in API Gateway.

--- a/tests/test_enterprise.yaml
+++ b/tests/test_enterprise.yaml
@@ -38,6 +38,13 @@
     - expected_status: [200]
 
 - test:
+    - name: 'Course run by ID endpoint v2 returns HTTP 200'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/course-runs/0123456789abcdefg'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [200]
+
+- test:
     - name: 'Course by key endpoint returns HTTP 200'
     - url: '/enterprise/v1/enterprise-catalogs/0123456789abcdefg/courses/0123456789abcdefg'
     - method: 'GET'
@@ -45,8 +52,22 @@
     - expected_status: [200]
 
 - test:
+    - name: 'Course by key endpoint v2 returns HTTP 200'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/courses/0123456789abcdefg'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [200]
+
+- test:
     - name: 'Program by UUID endpoint returns HTTP 200'
     - url: '/enterprise/v1/enterprise-catalogs/0123456789abcdefg/programs/0123456789abcdefg'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [200]
+
+- test:
+    - name: 'Program by UUID endpoint v2 returns HTTP 200'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/programs/0123456789abcdefg'
     - method: 'GET'
     - headers: {'Authorization': 'aeiou'}
     - expected_status: [200]
@@ -85,8 +106,22 @@
     - expected_status: [405]
 
 - test:
+    - name: 'Enterprise course run v2 POST is disabled'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/course-runs/0123456789abcdefg'
+    - method: 'POST'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [405]
+
+- test:
     - name: 'Enterprise course POST is disabled'
     - url: '/enterprise/v1/enterprise-catalogs/0123456789abcdefg/courses/0123456789abcdefg'
+    - method: 'POST'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [405]
+
+- test:
+    - name: 'Enterprise course v2 POST is disabled'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/courses/0123456789abcdefg'
     - method: 'POST'
     - headers: {'Authorization': 'aeiou'}
     - expected_status: [405]
@@ -99,8 +134,21 @@
     - expected_status: [405]
 
 - test:
+    - name: 'Enterprise program v2 POST is disabled'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/programs/0123456789abcdefg'
+    - method: 'POST'
+    - headers: {'Authorization': 'aeiou'}
+    - expected_status: [405]
+
+- test:
     - name: 'Enterprise course run GET rejected without authorization'
     - url: '/enterprise/v1/enterprise-catalogs/0123456789abcdefg/course-runs/0123456789abcdefg'
+    - method: 'GET'
+    - expected_status: [400]
+
+- test:
+    - name: 'Enterprise course run v2 GET rejected without authorization'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/course-runs/0123456789abcdefg'
     - method: 'GET'
     - expected_status: [400]
 
@@ -111,8 +159,20 @@
     - expected_status: [400]
 
 - test:
+    - name: 'Enterprise course v2 GET rejected without authorization'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/courses/0123456789abcdefg'
+    - method: 'GET'
+    - expected_status: [400]
+
+- test:
     - name: 'Enterprise program GET rejected without authorization'
     - url: '/enterprise/v1/enterprise-catalogs/0123456789abcdefg/programs/0123456789abcdefg'
+    - method: 'GET'
+    - expected_status: [400]
+
+- test:
+    - name: 'Enterprise program v2 GET rejected without authorization'
+    - url: '/enterprise/v2/enterprise-catalogs/0123456789abcdefg/programs/0123456789abcdefg'
     - method: 'GET'
     - expected_status: [400]
 
@@ -131,8 +191,36 @@
     - expected_status: [200]
 
 - test:
+    - name: 'Enterprise customer course enrollments endpoint v2 returns HTTP 200'
+    - url: '/enterprise/v2/enterprise-customer/0123456789abcdefg/course-enrollments'
+    - method: 'POST'
+    - headers: {'Authorization': 'aeiou', 'Content-Type': 'application/json'}
+    - body: >
+        [{
+            "course_run_id": "course-v1:edX+DemoX+Demo_Course",
+            "course_mode": "audit",
+            "user_email": "edx@example.com",
+            "email_students": true
+        }]
+    - expected_status: [200]
+
+- test:
     - name: 'Enterprise customer course enrollments endpoint rejected without authorization'
     - url: '/enterprise/v1/enterprise-customer/0123456789abcdefg/course-enrollments'
+    - method: 'POST'
+    - headers: {'Content-Type': 'application/json'}
+    - body: >
+        [{
+            "course_run_id": "course-v1:edX+DemoX+Demo_Course",
+            "course_mode": "audit",
+            "user_email": "edx@example.com",
+            "email_students": true
+        }]
+    - expected_status: [400]
+
+- test:
+    - name: 'Enterprise customer course enrollments endpoint v2 rejected without authorization'
+    - url: '/enterprise/v2/enterprise-customer/0123456789abcdefg/course-enrollments'
     - method: 'POST'
     - headers: {'Content-Type': 'application/json'}
     - body: >


### PR DESCRIPTION
This change uses the same implementation of the existing v1 enterprise
endpoints and merely adds a v2 shim that points to the same place. This
gives more consistent endpoints which will hopefully make it easier for
customers to migrate their code.

ENT-2938