### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # api-manager
-[![Build Status](https://travis-ci.org/edx/api-manager.svg?branch=master)](https://travis-ci.org/edx/api-manager)
+[![Build Status](https://travis-ci.com/edx/api-manager.svg?branch=master)](https://travis-ci.com/edx/api-manager)
 
 Specifications and optional lightweight service for routing clients of the Open edX REST API to various endpoints within the platform.
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089