### PR TITLE
feat: add v3 endpoint for enterprise learner summary endpoint

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -50,7 +50,7 @@ paths:
   "/enterprise/v1/enterprise-customer/{uuid}/course-enrollments":
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCourseEnrollments"
   "/enterprise/v1/enterprise-customer/{uuid}/learner-summary":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/8fc95e4/api.yaml#/endpoints/v1/enterpriseCustomerLearnerSummary"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v1/enterpriseCustomerLearnerSummary"
   # Enterprise Catalog IDA
   # These are served from the enterprise catalog IDA, but we surface them with the rest of the enterprise endpoints
   "/enterprise/v2/enterprise-catalogs":
@@ -67,7 +67,10 @@ paths:
   "/enterprise/v2/enterprise-customer/{uuid}/course-enrollments":
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCourseEnrollments"
   "/enterprise/v2/enterprise-customer/{uuid}/learner-summary":
-    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/8fc95e4/api.yaml#/endpoints/v1/enterpriseCustomerLearnerSummary"
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v1/enterpriseCustomerLearnerSummary"
+  # Learner Summary endpoint powered by Learner Progress Report V1 API
+  "/enterprise/v3/enterprise-customer/{uuid}/learner-summary":
+    $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v2/enterpriseCustomerLearnerSummary"
 
   # Registrar API Proxy
   # Note: There's an unresolved issue involving trailing slashes with proxy integrations in API Gateway.

--- a/tests/test_enterprise.yaml
+++ b/tests/test_enterprise.yaml
@@ -231,3 +231,17 @@
             "email_students": true
         }]
     - expected_status: [400]
+
+- test:
+    - name: 'Enterprise learner summary v3 endpoint returns HTTP 200'
+    - url: '/enterprise/v3/enterprise-customer/9101d3de36156cba/learner-summary'
+    - method: 'GET'
+    - headers: {'Authorization': 'aeiou', 'Content-Type': 'application/json'}
+    - expected_status: [200]
+
+- test:
+    - name: 'Enterprise learner summary v3 endpoint rejected without authorization'
+    - url: '/enterprise/v3/enterprise-customer/9101d3de36156cba/learner-summary'
+    - method: 'GET'
+    - headers: {'Content-Type': 'application/json'}
+    - expected_status: [400]


### PR DESCRIPTION
**Description:** Add api gateway spec for version v3 of `learner-summary` endpoint so that LPR V1 API can be accessed through new learner-summary endpoint.

**JIRA:** https://openedx.atlassian.net/browse/ENT-4881

**Dependency:** https://github.com/edx/edx-enterprise-data/pull/264