### PR TITLE
Revert "fix: use branch name directly"

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,7 +8,7 @@ on:
        branch:
          description: 'Target branch to create requirements PR against'
          required: true
-         default: 'master'
+         default: $default-branch
 jobs:
    call-upgrade-python-requirements-workflow:
     with:


### PR DESCRIPTION
Reverts edx/api-manager#142
This PR was made as a follow up to the cleanup job for reusable workflow. Now as we are going to revert that [PR](https://github.com/edx/api-manager/pull/139) too so firstly we have to revert this edx/api-manager#142 PR.