### PR TITLE
Make upgrade job fix

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,9 @@
 #
 boto==2.49.0
     # via google-compute-engine
-boto3==1.24.4
+boto3==1.24.9
     # via -r requirements/base.in
-botocore==1.27.4
+botocore==1.27.9
     # via
     #   -r requirements/base.in
     #   boto3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-astroid==2.11.5
+astroid==2.11.6
     # via pylint
 attrs==21.4.0
     # via
@@ -20,12 +20,12 @@ boto==2.49.0
     # via
     #   -r requirements/base.txt
     #   google-compute-engine
-boto3==1.24.4
+boto3==1.24.9
     # via
     #   -r requirements/base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.27.4
+botocore==1.27.9
     # via
     #   -r requirements/base.txt
     #   aws-xray-sdk
@@ -112,7 +112,7 @@ mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.in
-moto[cloudformation]==3.1.12
+moto[cloudformation]==3.1.13
     # via -r requirements/test.in
 networkx==2.8.4
     # via cfn-lint
@@ -142,7 +142,7 @@ pycparser==2.21
     # via cffi
 pycurl==7.45.1
     # via pyresttest
-pylint==2.14.1
+pylint==2.14.2
     # via -r requirements/test.in
 pyparsing==3.0.9
     # via
@@ -169,7 +169,7 @@ pyyaml==6.0
     #   moto
     #   openapi-spec-validator
     #   pyresttest
-requests==2.27.1
+requests==2.28.0
     # via
     #   docker
     #   moto


### PR DESCRIPTION
### Description
- `Python Requirements Upgrade` GitHub action job fails to run because of the `pip` && `pip-tools` version conflict in the environment. Ran the `make upgrade` job locally to fix the issue.

### Testing
- Tested that the job now works fine by running the GitHub Action against the updated branch.