### PR TITLE
feat: TNL-10746 add Studio content API

### DIFF
--- a/scripts/aws/deploy.py
+++ b/scripts/aws/deploy.py
@@ -136,6 +136,8 @@ if __name__ == '__main__':
                         help="Location of registrar IDA for request routing")
     parser.add_argument('--enterprise-catalog-host', required=True,
                         help="Location of enterprise catalog IDA for request routing")
+    parser.add_argument('--studio-host', required=True,
+                        help="Location of Studio IDA for request routing")
 
     args = parser.parse_args()
 
@@ -159,6 +161,7 @@ if __name__ == '__main__':
         'analytics_api_host': args.analytics_api_host,
         'registrar_host': args.registrar_host,
         'enterprise_catalog_host': args.enterprise_catalog_host,
+        'studio_host': args.studio_host,
     })
 
     # Apply stage setting updates.

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -73,7 +73,7 @@ paths:
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v2/enterpriseCustomerLearnerSummary"
 
   # Added by TNL team to support Studio content API
-  "api/contentstore/v1/file_asset/{proxy+}":
+  "/contentstore/v1/file_asset/{proxy+}":
     x-amazon-apigateway-any-method:
       parameters:
       - name: "proxy"
@@ -86,7 +86,7 @@ paths:
           integration.request.path.proxy: "method.request.path.proxy"
 
   # Added by TNL team to support Studio content API
-  "api/contentstore/v1/video_asset/{proxy+}":
+  "/contentstore/v1/video_asset/{proxy+}":
     x-amazon-apigateway-any-method:
       parameters:
       - name: "proxy"
@@ -99,7 +99,7 @@ paths:
           integration.request.path.proxy: "method.request.path.proxy"
 
   # Added by TNL team to support Studio content API
-  "api/contentstore/v1/xblock/{proxy+}":
+  "/contentstore/v1/xblock/{proxy+}":
     x-amazon-apigateway-any-method:
       parameters:
       - name: "proxy"

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -72,6 +72,45 @@ paths:
   "/enterprise/v3/enterprise-customer/{uuid}/learner-summary":
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v2/enterpriseCustomerLearnerSummary"
 
+  # Added by TNL team to support Studio content API
+  "api/contentstore/v1/file_asset/{proxy+}":
+    x-amazon-apigateway-any-method:
+      parameters:
+      - name: "proxy"
+        in: "path"
+      x-amazon-apigateway-integration:
+        type: "http_proxy"
+        uri: "https://${stageVariables.studio_host}/api/contentstore/v1/file_asset/{proxy}"
+        httpMethod: "ANY"
+        requestParameters:
+          integration.request.path.proxy: "method.request.path.proxy"
+
+  # Added by TNL team to support Studio content API
+  "api/contentstore/v1/video_asset/{proxy+}":
+    x-amazon-apigateway-any-method:
+      parameters:
+      - name: "proxy"
+        in: "path"
+      x-amazon-apigateway-integration:
+        type: "http_proxy"
+        uri: "https://${stageVariables.studio_host}/api/contentstore/v1/video_asset/{proxy}"
+        httpMethod: "ANY"
+        requestParameters:
+          integration.request.path.proxy: "method.request.path.proxy"
+
+  # Added by TNL team to support Studio content API
+  "api/contentstore/v1/xblock/{proxy+}":
+    x-amazon-apigateway-any-method:
+      parameters:
+      - name: "proxy"
+        in: "path"
+      x-amazon-apigateway-integration:
+        type: "http_proxy"
+        uri: "https://${stageVariables.studio_host}/api/contentstore/v1/xblock/{proxy}"
+        httpMethod: "ANY"
+        requestParameters:
+          integration.request.path.proxy: "method.request.path.proxy"
+
   # Registrar API Proxy
   # Note: There's an unresolved issue involving trailing slashes with proxy integrations in API Gateway.
   # Apparently all trailing slashes included in the value of {proxy} are trimmed, see this AWS
@@ -155,3 +194,4 @@ x-edx-api-vendors:
     - "analytics_api_host"
     - "registrar_host"
     - "enterprise_catalog_host"
+    - "studio_host"


### PR DESCRIPTION
Currently, the API Gateway (on stage) is operating off of the "blue" stage. The deploy script in this repo will add Studio content APIs to this stage on the AWS API Gateway. That deploy script takes command line arguments, and the values last used with a deploy are available from the AWS console. They were:

![Screenshot 2023-06-29 at 3 58 50 PM](https://github.com/edx/api-manager/assets/206259/b1286968-3b72-4d76-a6bf-c638dbb00a7f)

This PR adds a new command line argument pointing the AWS gateway to the edX platform's Studio IDA. The PR also adds three REST API endpoints off of this host. These service:

1. file asset uploads
2. video asset uploads
3. XBlock CRUD operations

The changes in the `api.yaml` file rely on wildcard mechanisms offered by [AWS integration with proxy resources](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html). These effectively pass through requests and responses between the API Gateway and the edX platform. [This article](https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html) contains a detailed example that clarifies what the declarations in `api.yaml` do.

Note that even though only the XBlock CRUD endpoint currently exists in `edx-platform`, merging this request and running the deploy script should not be problematic. The new endpoints have not been advertised; and even if someone makes a request against them, the following language from the example linked above applies: "The run-time instance of the proxy resource path does not correspond to a backend endpoint and the resulting request is invalid. As a result, a 400 Bad Request response is returned "
