### PR TITLE
fix: import common deploy package with absolute path

### DIFF
--- a/scripts/aws/deploy.py
+++ b/scripts/aws/deploy.py
@@ -4,7 +4,7 @@
 
 import argparse
 import logging
-from .common.deploy import deploy
+from aws.common.deploy import deploy
 
 if __name__ == '__main__':
 

--- a/scripts/aws/deploy_studio.py
+++ b/scripts/aws/deploy_studio.py
@@ -4,7 +4,7 @@
 
 import argparse
 import logging
-from .common.deploy import deploy
+from aws.common.deploy import deploy
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
fix: import common deploy package with absolute path

another follow-on attempt to fix the gocd pipeline error that does not occur locally.