### PR TITLE
fix: make scripts directory a package, for absolute imports.

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# intentionally empty

--- a/scripts/aws/deploy.py
+++ b/scripts/aws/deploy.py
@@ -4,7 +4,7 @@
 
 import argparse
 import logging
-from aws.common.deploy import deploy
+from scripts.aws.common.deploy import deploy
 
 if __name__ == '__main__':
 

--- a/scripts/aws/deploy_studio.py
+++ b/scripts/aws/deploy_studio.py
@@ -4,7 +4,7 @@
 
 import argparse
 import logging
-from aws.common.deploy import deploy
+from scripts.aws.common.deploy import deploy
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
fix: make scripts directory a package, for absolute imports.

Make the top level `scripts` director a package, to fix ModuleNotFoundError?