### PR TITLE
fix: use enum value for nodejs18, not explicit version

### DIFF
--- a/scripts/aws/monitor.py
+++ b/scripts/aws/monitor.py
@@ -320,7 +320,7 @@ if __name__ == '__main__':
     zip_file_name = create_lambda_function_zip(j2_env, tmpdirname, args.splunk_host,
                                                args.splunk_token, lambda_function_name)
     vpc_config = {'SubnetIds': args.subnet_list, 'SecurityGroupIds': args.sg_list}
-    create_lambda_function(lambda_client, lambda_function_name, 'nodejs18.18.0', lambda_exec_role_arn,
+    create_lambda_function(lambda_client, lambda_function_name, 'nodejs18.x', lambda_exec_role_arn,
                            'index.handler', zip_file_name,
                            'Demonstrates logging events to Splunk HTTP Event '
                            'Collector, accessing resources in a VPC', args.lambda_timeout, args.lambda_memory,


### PR DESCRIPTION
fix: use enum value for nodejs18, not explicit version