### PR TITLE
feat: TNL-10746 fix integrations to all be v0 versions

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -146,7 +146,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v1/file_assets/{proxy}"
+        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/file_assets/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"


### PR DESCRIPTION
file_assets was inadvertently left as a v1 in the last merge