### PR TITLE
Bszabo/tnl 10746 omnibus

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -146,7 +146,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v1/file_assets/{proxy}"
+        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/file_assets/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -146,7 +146,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/file_assets/{proxy}"
+        uri: "https://${stageVariables.authoring_host}/api/contentstore/v0/file_assets/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
@@ -158,7 +158,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/videos/uploads/{proxy}"
+        uri: "https://${stageVariables.authoring_host}/api/contentstore/v0/videos/uploads/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
@@ -170,7 +170,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/videos/images/{proxy}"
+        uri: "https://${stageVariables.authoring_host}/api/contentstore/v0/videos/images/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
@@ -182,7 +182,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/video_transcripts/{proxy}"
+        uri: "https://${stageVariables.authoring_host}/api/contentstore/v0/video_transcripts/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
@@ -194,7 +194,7 @@ paths:
         in: "path"
       x-amazon-apigateway-integration:
         type: "http_proxy"
-        uri: "https://${stageVariables.cms_host}/api/contentstore/v0/xblock/{proxy}"
+        uri: "https://${stageVariables.authoring_host}/api/contentstore/v0/xblock/{proxy}"
         httpMethod: "ANY"
         requestParameters:
           integration.request.path.proxy: "method.request.path.proxy"
@@ -217,4 +217,4 @@ x-edx-api-vendors:
     - "analytics_api_host"
     - "registrar_host"
     - "enterprise_catalog_host"
-    - "cms_host"
+    - "authoring_host"


### PR DESCRIPTION
This work is per TNL-10746 and is intended to allow end-to-end testing of the API gateway on stage. It partners with an edx-internal pull request (https://github.com/edx/edx-internal/pull/9589)

At issue is that the internal platform APIs for the authoring API are located on studio.stage.edx.org. Configuration of the authoring API for the API gateway needs to depend on a stage variable set up by GoCD on push operations of this repo. 

To test: verify that integration settings for authoring endpoints are in terms of the authoring-host stage variable