### PR TITLE
feat: Define license assign endpoint on Gateway

### DIFF
--- a/scripts/aws/deploy.py
+++ b/scripts/aws/deploy.py
@@ -47,6 +47,8 @@ if __name__ == '__main__':
                         help="Location of enterprise catalog IDA for request routing")
     parser.add_argument('--authoring-host', required=True,
                         help="Location of Studio for authoring request routing")
+    parser.add_argument('--license-manager-host', required=True,
+                        help="Location of License Manager IDA for request routing")
 
     cli_args = parser.parse_args()
     integration_settings = {
@@ -59,7 +61,8 @@ if __name__ == '__main__':
         'analytics_api_host': cli_args.analytics_api_host,
         'registrar_host': cli_args.registrar_host,
         'enterprise_catalog_host': cli_args.enterprise_catalog_host,
-        'authoring_host': cli_args.authoring_host
+        'authoring_host': cli_args.authoring_host,
+        'license_manager_host': cli_args.license_manager_host
     }
     stage_settings = {
         'log_level': cli_args.log_level,

--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -71,6 +71,10 @@ paths:
   # Learner Summary endpoint powered by Learner Progress Report V1 API
   "/enterprise/v3/enterprise-customer/{uuid}/learner-summary":
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v2/enterpriseCustomerLearnerSummary"
+  # License Manager IDA
+  # These are served from the license manager IDA, but we surface them with the rest of the enterprise endpoints
+  "/enterprise/v1/subscriptions/{uuid}/licenses/assign":
+    $ref: "https://raw.githubusercontent.com/edx/license-manager/f2f38ee/api.yaml#/endpoints/v1/assignLicenses"
 
   # Registrar API Proxy
   # Note: There's an unresolved issue involving trailing slashes with proxy integrations in API Gateway.
@@ -218,3 +222,4 @@ x-edx-api-vendors:
     - "registrar_host"
     - "enterprise_catalog_host"
     - "authoring_host"
+    - "license_manager_host"

--- a/tests/test_enterprise.yaml
+++ b/tests/test_enterprise.yaml
@@ -245,3 +245,37 @@
     - method: 'GET'
     - headers: {'Content-Type': 'application/json'}
     - expected_status: [400]
+
+- test:
+    - name: 'License assign endpoint returns HTTP 200'
+    - url: '/enterprise/v1/subscriptions/9101d3de36156cba/licenses/assign'
+    - method: 'POST'
+    - headers: {'Authorization': 'aeiou', 'Content-Type': 'application/json'}
+    - body: >
+        [
+            {
+                "user_emails": ["edx@example.com", "abc@example.com"],
+                "user_sfids": ["efghijk", "abcdefg"],
+                "greeting": "hello",
+                "closing": "bye",
+                "notify_users": true
+            }
+        ]
+    - expected_status: [200]
+
+- test:
+    - name: 'License assign endpoint rejected without authorization HTTP 200'
+    - url: '/enterprise/v1/subscriptions/9101d3de36156cba/licenses/assign'
+    - method: 'POST'
+    - headers: {'Content-Type': 'application/json'}
+    - body: >
+        [
+            {
+                "user_emails": ["edx@example.com", "abc@example.com"],
+                "user_sfids": ["efghijk", "abcdefg"],
+                "greeting": "hello",
+                "closing": "bye",
+                "notify_users": true
+            }
+        ]
+    - expected_status: [400]


### PR DESCRIPTION
This PR adds a definition for license-manager assign endpoint on the Omnibus API to expose it to Gateway. 

Host variable is also added to pick up host value for the service. https://github.com/edx/edx-internal/pull/9905

**JIRA**: https://2u-internal.atlassian.net/browse/ENT-7995