### PR TITLE
Bszabo/tnl 11327 file upload

### DIFF
--- a/scripts/aws/common/deploy.py
+++ b/scripts/aws/common/deploy.py
@@ -64,7 +64,7 @@ def deploy_api(client, rest_api_id, swagger_filename, stage_name, stage_variable
         restApiId=rest_api_id,
         mode='overwrite',
         body=swagger.read(),
-        binaryMediaTypes=['multipart/form-data']  # This MIME needs to be binary for file uploads
+        parameters={'binaryMediaTypes': 'multipart/form-data'},  # This MIME needs to be binary for file uploads
     )
     logging.info('Existing API ID "%s" updated (name "%s")', api_response['id'], api_response['name'])
 

--- a/scripts/aws/common/deploy.py
+++ b/scripts/aws/common/deploy.py
@@ -60,7 +60,12 @@ def deploy_api(client, rest_api_id, swagger_filename, stage_name, stage_variable
 
     swagger = open(swagger_filename, 'r', encoding="utf-8")  # pylint: disable=consider-using-with
 
-    api_response = client.put_rest_api(restApiId=rest_api_id, mode='overwrite', body=swagger.read())
+    api_response = client.put_rest_api(
+        restApiId=rest_api_id,
+        mode='overwrite',
+        body=swagger.read(),
+        binaryMediaTypes=['multipart/form-data']  # This MIME needs to be binary for file uploads
+    )
     logging.info('Existing API ID "%s" updated (name "%s")', api_response['id'], api_response['name'])
 
     deployment_response = client.create_deployment(


### PR DESCRIPTION
Set multipart/form-data MIME type to be binary to support file uploads through the API Gateway. Note that this binary type was changed on request by the SRE and confirmed to work. At that time, the SRE team requested that this be replaced by programmatic configuration sometime soon.

This work is per TNL-11327

Testing:
Deploy an API.  Then, on the AWS API Gateway console, go to the just-deployed API object, select "API Settings", go to the Binary Media Types panel, and confirm that 'multipart/form-data' now appears in the list of binary media types.

Prior to this PR being created, the boto functionality was tested on the playground AWS account, with the following script:

import botocore.session
session = botocore.session.get_session()
apig = session.create_client('apigateway', 'us-east-1')
api_id='ndo8mvha20'
apig.put_rest_api(
            restApiId=api_id,
            body='''
            {
              "swagger" : "2.0",
              "info":{
                    "version": "1.0.0",
                    "title":"Open edX"
                },
                "host": "api.edx.org",
                "schemes":["https"],
                    "version": "1.0.0",
                    "title":"Open edX"
                },
                "host": "api.edx.org",
                "schemes":["https"],
                "paths":{}
            }''',
            parameters={'binaryMediaTypes': 'multipart/form-data'},
            mode='overwrite')