### PR TITLE
fix: rename body param for assign endpoint

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -51,6 +51,10 @@ paths:
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise/260055b/api.yaml#/endpoints/v1/enterpriseCustomerCourseEnrollments"
   "/enterprise/v1/enterprise-customer/{uuid}/learner-summary":
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v1/enterpriseCustomerLearnerSummary"
+  # License Manager IDA
+  # These are served from the license manager IDA, but we surface them with the rest of the enterprise endpoints
+  "/enterprise/v1/subscriptions/{uuid}/licenses/assign":
+    $ref: "https://raw.githubusercontent.com/edx/license-manager/eb9407e/api.yaml#/endpoints/v1/assignLicenses"
   # Enterprise Catalog IDA
   # These are served from the enterprise catalog IDA, but we surface them with the rest of the enterprise endpoints
   "/enterprise/v2/enterprise-catalogs":
@@ -71,10 +75,6 @@ paths:
   # Learner Summary endpoint powered by Learner Progress Report V1 API
   "/enterprise/v3/enterprise-customer/{uuid}/learner-summary":
     $ref: "https://raw.githubusercontent.com/edx/edx-enterprise-data/eb793cf/api.yaml#/endpoints/v2/enterpriseCustomerLearnerSummary"
-  # License Manager IDA
-  # These are served from the license manager IDA, but we surface them with the rest of the enterprise endpoints
-  "/enterprise/v1/subscriptions/{uuid}/licenses/assign":
-    $ref: "https://raw.githubusercontent.com/edx/license-manager/f2f38ee/api.yaml#/endpoints/v1/assignLicenses"
 
   # Registrar API Proxy
   # Note: There's an unresolved issue involving trailing slashes with proxy integrations in API Gateway.


### PR DESCRIPTION
This PR is an attempt to fix the error that came up during deploying api to Gateway. 
```
botocore.errorfactory.BadRequestException: An error occurred (BadRequestException) when calling the PutRestApi operation: Errors found during import:
	Unable to create model for 'body_1': Model name must be alphanumeric: body_1