### PR TITLE
Bszabo/tnl 11327 file upload

### DIFF
--- a/scripts/aws/common/deploy.py
+++ b/scripts/aws/common/deploy.py
@@ -64,7 +64,7 @@ def deploy_api(client, rest_api_id, swagger_filename, stage_name, stage_variable
         restApiId=rest_api_id,
         mode='overwrite',
         body=swagger.read(),
-        binaryMediaTypes=['multipart/form-data']  # This MIME needs to be binary for file uploads
+        parameters={'binaryMediaTypes': 'multipart/form-data'},  # This MIME needs to be binary for file uploads
     )
     logging.info('Existing API ID "%s" updated (name "%s")', api_response['id'], api_response['name'])
 

--- a/scripts/aws/common/deploy.py
+++ b/scripts/aws/common/deploy.py
@@ -64,7 +64,7 @@ def deploy_api(client, rest_api_id, swagger_filename, stage_name, stage_variable
         restApiId=rest_api_id,
         mode='overwrite',
         body=swagger.read(),
-        parameters={'binaryMediaTypes': 'multipart/form-data'},  # This MIME needs to be binary for file uploads
+        binaryMediaTypes=['multipart/form-data']  # This MIME needs to be binary for file uploads
     )
     logging.info('Existing API ID "%s" updated (name "%s")', api_response['id'], api_response['name'])
 

--- a/scripts/aws/common/deploy.py
+++ b/scripts/aws/common/deploy.py
@@ -60,7 +60,12 @@ def deploy_api(client, rest_api_id, swagger_filename, stage_name, stage_variable
 
     swagger = open(swagger_filename, 'r', encoding="utf-8")  # pylint: disable=consider-using-with
 
-    api_response = client.put_rest_api(restApiId=rest_api_id, mode='overwrite', body=swagger.read())
+    api_response = client.put_rest_api(
+        restApiId=rest_api_id,
+        mode='overwrite',
+        body=swagger.read(),
+        binaryMediaTypes=['multipart/form-data']  # This MIME needs to be binary for file uploads
+    )
     logging.info('Existing API ID "%s" updated (name "%s")', api_response['id'], api_response['name'])
 
     deployment_response = client.create_deployment(


### PR DESCRIPTION
There was nothing wrong with yesterday's reverted 2ade446bd9109e91825a60d22b6d672936465da6 commit. At issue was a build pipeline breakage from before.

This PR follows a fix of that breakage and a rebase/forced push operation on this branch.