### PR TITLE
fix: include missing response for bulk-enroll

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -54,11 +54,11 @@ paths:
   # License Manager IDA
   # These are served from the license manager IDA, but we surface them with the rest of the enterprise endpoints
   "/enterprise/v1/subscriptions/{uuid}/licenses/assign":
-    $ref: "https://raw.githubusercontent.com/edx/license-manager/eb9407e/api.yaml#/endpoints/v1/assignLicenses"
+    $ref: "https://raw.githubusercontent.com/edx/license-manager/b9e9ec9/api.yaml#/endpoints/v1/assignLicenses"
   "/enterprise/v1/subscriptions/{uuid}/licenses/bulk-revoke":
       $ref: "https://raw.githubusercontent.com/edx/license-manager/b9e9ec9/api.yaml#/endpoints/v1/revokeLicenses"
   "/enterprise/v1/bulk-license-enrollment":
-    $ref: "https://raw.githubusercontent.com/edx/license-manager/227342c/api.yaml#/endpoints/v1/bulkLicenseEnrollment"
+    $ref: "https://raw.githubusercontent.com/edx/license-manager/b9e9ec9/api.yaml#/endpoints/v1/bulkLicenseEnrollment"
   # Enterprise Catalog IDA
   # These are served from the enterprise catalog IDA, but we surface them with the rest of the enterprise endpoints
   "/enterprise/v2/enterprise-catalogs":


### PR DESCRIPTION
This change will include 201 in gateway responses for correct service to gateway response mapping. 