### PR TITLE
[ENT-8345] fix: add trailing slash & 301 response to subscription endpoint

### DIFF
--- a/swagger/api.yaml
+++ b/swagger/api.yaml
@@ -54,7 +54,7 @@ paths:
   # License Manager IDA
   # These are served from the license manager IDA, but we surface them with the rest of the enterprise endpoints
   "/enterprise/v1/subscriptions":
-    $ref: "https://raw.githubusercontent.com/edx/license-manager/d156536/api.yaml#/endpoints/v1/subscriptionsList"
+    $ref: "https://raw.githubusercontent.com/edx/license-manager/eb99e98/api.yaml#/endpoints/v1/subscriptionsList"
   "/enterprise/v1/subscriptions/{uuid}/licenses/assign":
     $ref: "https://raw.githubusercontent.com/edx/license-manager/b9e9ec9/api.yaml#/endpoints/v1/assignLicenses"
   "/enterprise/v1/subscriptions/{uuid}/licenses/bulk-revoke":


### PR DESCRIPTION
Description:
Update hash for the fix of adding trailing slash and 301 response code to the subscription list endpoint