### PR TITLE
chore: rename arbi-bom to orbi-bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     schedule:
         interval: "weekly"
     reviewers:
-      - "edx/arbi-bom"
+      - "edx/orbi-bom"

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -55,10 +55,9 @@ jobs:
           --target-branch="${{ env.target_branch }}" --base-branch-name="upgrade-python-requirements" \
           --commit-message="chore: Updating Python Requirements" --pr-title="Python Requirements Update" \
           --pr-body="Python requirements update.Please review the [changelogs](https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs) for the upgraded packages." \
-          --user-reviewers="" --team-reviewers="arbi-bom" --delete-old-pull-requests
+          --user-reviewers="" --team-reviewers="orbi-bom" --delete-old-pull-requests
 
-      - name: Send failure notification
-        if: ${{ failure() }}
+      - name: Send notification
         uses: dawidd6/action-send-mail@v4
         with:
           server_address: email-smtp.us-east-1.amazonaws.com
@@ -66,6 +65,6 @@ jobs:
           username: ${{secrets.EDX_SMTP_USERNAME}}
           password: ${{secrets.EDX_SMTP_PASSWORD}}
           subject: Upgrade python requirements workflow failed in ${{github.repository}}
-          to: arbi-bom@edx.org
+          to: orbi-bom-upgrade-prs@2u-internal.jsmalerts.atlassian.net
           from: github-actions <github-actions@edx.org>
           body: Upgrade python requirements workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Description

Update GitHub workflow failure email notifications to use [orbi-bom@edx.org](mailto:orbi-bom@edx.org) instead of [arbi-bom@edx.org](mailto:arbi-bom@edx.org) 
Updates team reviewer assignment in pull request creation from arbi-bom to orbi-bom 

Related PRs

- [ ] https://github.com/edx/edx-arch-experiments/pull/1107
- [ ] https://github.com/edx/devstack/pull/174
- [ ] https://github.com/edx/edx-internal/pull/13377
- [ ] https://github.com/edx/repo-health-data/pull/312
- [ ] https://github.com/edx/jenkins-job-dsl-internal/pull/962

Jira - [BOMS-39](https://2u-internal.atlassian.net/browse/BOMS-39)